### PR TITLE
Add installation hints for prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ gelegt und sind per `.gitignore` vom Repository ausgeschlossen.
 - Docker und Docker Compose (Plugin oder `docker-compose`).
 - `curl` und `git`.
 
+**Kurzinstallation (Debian/Ubuntu):**
+
+```bash
+sudo apt update
+sudo apt install -y docker.io docker-compose-plugin curl git
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+> Nach dem Hinzufügen zur `docker`-Gruppe ist eine neue Terminal-Sitzung nötig,
+> damit die Berechtigungen greifen.
+
+Installationshinweise für weitere Distributionen stehen in
+[docs/requirements-installation.md](docs/requirements-installation.md).
+
 Das Installer-Skript kann fehlende Pakete optional automatisch nachinstallieren.
 
 ## Installer verwenden

--- a/docs/requirements-installation.md
+++ b/docs/requirements-installation.md
@@ -1,0 +1,56 @@
+# Schnellinstallation der Voraussetzungen
+
+Die folgenden Kurz-Anleitungen zeigen, wie sich die in der README genannten
+Pakete (`docker`, `docker compose`, `curl`, `git`) auf gängigen Distributionen
+installieren lassen. Alle Beispiele setzen `sudo`-Rechte voraus.
+
+> **Hinweis:** Nach dem Hinzufügen zur `docker`-Gruppe ist eine neue
+> Terminal-Sitzung (oder Ab- und Anmeldung) erforderlich, damit die
+> Berechtigungen greifen.
+
+## Debian / Ubuntu / Derivate
+
+```bash
+sudo apt update
+sudo apt install -y docker.io docker-compose-plugin curl git
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+## RHEL / CentOS / Rocky Linux / AlmaLinux
+
+```bash
+sudo dnf install -y dnf-plugins-core curl git
+sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+## openSUSE Leap / Tumbleweed
+
+```bash
+sudo zypper refresh
+sudo zypper install -y docker docker-compose curl git
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+## Arch Linux / Manjaro
+
+```bash
+sudo pacman -Syu --needed docker docker-compose curl git
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+## Installation prüfen
+
+```bash
+docker --version
+docker compose version
+curl --version
+git --version
+```
+
+Wenn alle Befehle eine Versionsnummer ausgeben, sind die Voraussetzungen erfüllt.


### PR DESCRIPTION
## Summary
- add a Debian/Ubuntu quick-install snippet to the prerequisites section and link to extended instructions
- document installation commands for all supported distributions in a dedicated guide

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c92b082fd08333841b006e5206032f