### PR TITLE
Switch PXE service to netbootxyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ vereinfachen soll.
 |---------------|------------------------------------------------------------------------------|
 | `db`          | MariaDB 10.11 als zentrales Backend für OPSI.                                |
 | `opsi-server` | OPSI-Server inklusive Config-API und Depot. Greift auf DB und Konfigurationen zu. |
-| `pxe`         | TFTP-Service für PXE-Boot (Standard: `ghcr.io/linuxserver/tftp`).             |
+| `pxe`         | netboot.xyz TFTP/HTTP-Service mit Webinterface (Standard: `netbootxyz/netbootxyz`). |
 
 ## Repository-Struktur
 

--- a/configs/pxe/pxe.conf.example
+++ b/configs/pxe/pxe.conf.example
@@ -1,10 +1,11 @@
 # Example dnsmasq PXE configuration snippet for OpsiSuit.
 # Copy to configs/pxe/pxe.conf and adapt addresses and filenames.
+# The netboot.xyz container serves boot files from /config/menus.
 
 port=0
 log-dhcp
 enable-tftp
-tftp-root=/tftpboot
+tftp-root=/config/menus
 
 dhcp-range=192.168.56.100,192.168.56.200,12h
 dhcp-option=3,192.168.56.1

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -25,9 +25,10 @@ OPSI_DEPOT_PORT=4441
 OPSI_WEBUI_PORT=4443
 
 # PXE / TFTP service configuration
-PXE_IMAGE=ghcr.io/linuxserver/tftp:latest
+PXE_IMAGE=netbootxyz/netbootxyz:latest
 PXE_TFTP_PORT=69
 PXE_HTTP_PORT=8080
+PXE_WEBAPP_PORT=3000
 PXE_DATA_SUBNET=0.0.0.0/0
 PXE_DEFAULT_MENU=default
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,12 +47,11 @@ services:
       - "${OPSI_API_PORT:-4447}:4447"
       - "${OPSI_DEPOT_PORT:-4441}:4441"
       - "${OPSI_WEBUI_PORT:-4443}:4443"
-      - "${PXE_HTTP_PORT:-8080}:8080"
     networks:
       - opsisuit
 
   pxe:
-    image: ${PXE_IMAGE:-ghcr.io/linuxserver/tftp:latest}
+    image: ${PXE_IMAGE:-netbootxyz/netbootxyz:latest}
     container_name: opsisuit-pxe
     restart: unless-stopped
     environment:
@@ -61,9 +60,11 @@ services:
       TZ: ${TIMEZONE:-UTC}
     ports:
       - "${PXE_TFTP_PORT:-69}:69/udp"
+      - "${PXE_HTTP_PORT:-8080}:80"
+      - "${PXE_WEBAPP_PORT:-3000}:3000"
     volumes:
-      - ../data/pxe:/tftpboot
       - ../configs/pxe:/config
+      - ../data/pxe:/assets
     networks:
       - opsisuit
 

--- a/scripts/opsisuit-installer.sh
+++ b/scripts/opsisuit-installer.sh
@@ -40,6 +40,7 @@ ENV_VARIABLES=(
   AGENT_SECRET
   AGENT_POLL_INTERVAL
   PXE_HTTP_PORT
+  PXE_WEBAPP_PORT
   PXE_TFTP_PORT
   SERVICE_UID
   SERVICE_GID
@@ -127,11 +128,12 @@ get_env_default() {
     AGENT_SECRET) echo "ChangeMeAgentSecret!" ;;
     AGENT_POLL_INTERVAL) echo "3600" ;;
     PXE_HTTP_PORT) echo "8080" ;;
+    PXE_WEBAPP_PORT) echo "3000" ;;
     PXE_TFTP_PORT) echo "69" ;;
     SERVICE_UID) echo "0" ;;
     SERVICE_GID) echo "0" ;;
     TIMEZONE) echo "UTC" ;;
-    PXE_IMAGE) echo "ghcr.io/linuxserver/tftp:latest" ;;
+    PXE_IMAGE) echo "netbootxyz/netbootxyz:latest" ;;
     *) echo "" ;;
   esac
 }
@@ -204,6 +206,7 @@ build_prompt() {
       AGENT_SECRET) label="Agent-Secret für Client-Registrierung (Änderung empfohlen)" ;;
       AGENT_POLL_INTERVAL) label="Abfrageintervall des Agenten in Sekunden" ;;
       PXE_HTTP_PORT) label="HTTP-Port für PXE-Bereitstellung" ;;
+      PXE_WEBAPP_PORT) label="Webinterface-Port für netboot.xyz" ;;
       PXE_TFTP_PORT) label="UDP-Port für PXE/TFTP" ;;
       SERVICE_UID) label="UID für Container-Dienste" ;;
       SERVICE_GID) label="GID für Container-Dienste" ;;
@@ -238,6 +241,7 @@ build_prompt() {
       AGENT_SECRET) label="Agent secret for client registration (change recommended)" ;;
       AGENT_POLL_INTERVAL) label="Agent polling interval in seconds" ;;
       PXE_HTTP_PORT) label="HTTP port for PXE provisioning" ;;
+      PXE_WEBAPP_PORT) label="Web interface port for netboot.xyz" ;;
       PXE_TFTP_PORT) label="UDP port for PXE/TFTP" ;;
       SERVICE_UID) label="UID for container services" ;;
       SERVICE_GID) label="GID for container services" ;;
@@ -264,7 +268,7 @@ validate_env_value() {
   local numeric_value=0
 
   case "$var" in
-    DB_PORT|OPSI_API_PORT|OPSI_DEPOT_PORT|OPSI_WEBUI_PORT|PXE_HTTP_PORT|PXE_TFTP_PORT)
+    DB_PORT|OPSI_API_PORT|OPSI_DEPOT_PORT|OPSI_WEBUI_PORT|PXE_HTTP_PORT|PXE_WEBAPP_PORT|PXE_TFTP_PORT)
       if [[ ! "$value" =~ ^[0-9]+$ ]]; then
         warn_invalid_port
         return 1


### PR DESCRIPTION
## Summary
- replace the retired linuxserver TFTP image with the maintained netbootxyz/netbootxyz container and expose its HTTP and web UI ports in docker-compose
- align the docker environment defaults and installer prompts with the new image and add a configurable PXE web interface port
- refresh PXE documentation to reference the netboot.xyz stack and its /config/menus TFTP root

## Testing
- ./scripts/opsisuit-installer.sh --help


------
https://chatgpt.com/codex/tasks/task_e_68c948dab56c833396956c8ad9507c81