### PR TITLE
Ensure opsi-server can resolve database service

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,9 @@ services:
     ports:
       - "${DB_PORT:-3306}:3306"
     networks:
-      - opsisuit
+      opsisuit:
+        aliases:
+          - db
 
   opsi-server:
     image: ${OPSI_SERVER_IMAGE:-uibmz/opsi-server:4.2}


### PR DESCRIPTION
## Summary
- expose the MariaDB container on the Compose network with the `db` alias so the opsi-server can resolve it

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9539f2920833381116be19502a679