### PR TITLE
Add Redis cache service to OpsiSuit stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ vereinfachen soll.
 | Service       | Beschreibung                                                                 |
 |---------------|------------------------------------------------------------------------------|
 | `db`          | MariaDB 10.11 als zentrales Backend für OPSI.                                |
+| `redis`       | Redis 7 als In-Memory-Cache und Message-Broker für den OPSI-Server.          |
 | `opsi-server` | OPSI-Server inklusive Config-API und Depot. Greift auf DB und Konfigurationen zu. |
 | `pxe`         | netboot.xyz TFTP/HTTP-Service mit Webinterface (Standard: `netbootxyz/netbootxyz`). |
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,6 +15,10 @@ DB_USER=opsi
 DB_PASSWORD=ChangeMeDb!
 DB_PORT=3306
 
+# Redis cache
+REDIS_IMAGE=redis:7-alpine
+REDIS_PORT=6379
+
 # OPSI server configuration
 OPSI_SERVER_IMAGE=uibmz/opsi-server:4.2
 OPSI_SERVER_FQDN=opsi.local

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,12 +24,30 @@ services:
         aliases:
           - db
 
+  redis:
+    image: ${REDIS_IMAGE:-redis:7-alpine}
+    container_name: opsisuit-redis
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+    volumes:
+      - ../data/redis:/data
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      opsisuit:
+        aliases:
+          - redis
+
   opsi-server:
     image: ${OPSI_SERVER_IMAGE:-uibmz/opsi-server:4.2}
     container_name: opsisuit-server
     restart: unless-stopped
     depends_on:
       - db
+      - redis
     environment:
       OPSI_ADMIN_USER: ${OPSI_ADMIN_USER:-opsiadmin}
       OPSI_ADMIN_PASSWORD: ${OPSI_ADMIN_PASSWORD:?OPSI_ADMIN_PASSWORD is required}
@@ -38,6 +56,8 @@ services:
       OPSI_DB_NAME: ${DB_NAME:-opsi}
       OPSI_DB_USER: ${DB_USER:-opsi}
       OPSI_DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      OPSI_REDIS_HOST: redis
+      OPSI_REDIS_PORT: ${REDIS_PORT:-6379}
       AGENT_SECRET: ${AGENT_SECRET:-ChangeMeAgentSecret!}
       AGENT_POLL_INTERVAL: ${AGENT_POLL_INTERVAL:-3600}
     volumes:

--- a/scripts/opsisuit-installer.sh
+++ b/scripts/opsisuit-installer.sh
@@ -30,6 +30,8 @@ ENV_VARIABLES=(
   DB_USER
   DB_PASSWORD
   DB_PORT
+  REDIS_IMAGE
+  REDIS_PORT
   OPSI_ADMIN_USER
   OPSI_ADMIN_PASSWORD
   OPSI_SERVER_FQDN
@@ -118,6 +120,8 @@ get_env_default() {
     DB_USER) echo "opsi" ;;
     DB_PASSWORD) echo "" ;;
     DB_PORT) echo "3306" ;;
+    REDIS_IMAGE) echo "redis:7-alpine" ;;
+    REDIS_PORT) echo "6379" ;;
     OPSI_ADMIN_USER) echo "opsiadmin" ;;
     OPSI_ADMIN_PASSWORD) echo "" ;;
     OPSI_SERVER_FQDN) echo "opsi.local" ;;
@@ -196,6 +200,8 @@ build_prompt() {
       DB_USER) label="Datenbankbenutzer" ;;
       DB_PASSWORD) label="Passwort für den Datenbankbenutzer" ;;
       DB_PORT) label="Datenbank-Portnummer" ;;
+      REDIS_IMAGE) label="Container-Image für Redis" ;;
+      REDIS_PORT) label="Redis-Portnummer" ;;
       OPSI_ADMIN_USER) label="OPSI-Administratorbenutzer" ;;
       OPSI_ADMIN_PASSWORD) label="Passwort für den OPSI-Administrator" ;;
       OPSI_SERVER_FQDN) label="FQDN des OPSI-Servers" ;;
@@ -231,6 +237,8 @@ build_prompt() {
       DB_USER) label="Database user" ;;
       DB_PASSWORD) label="Password for the database user" ;;
       DB_PORT) label="Database port number" ;;
+      REDIS_IMAGE) label="Container image for Redis" ;;
+      REDIS_PORT) label="Redis port number" ;;
       OPSI_ADMIN_USER) label="OPSI administrator user" ;;
       OPSI_ADMIN_PASSWORD) label="Password for the OPSI administrator" ;;
       OPSI_SERVER_FQDN) label="Fully qualified domain name of the OPSI server" ;;
@@ -268,7 +276,7 @@ validate_env_value() {
   local numeric_value=0
 
   case "$var" in
-    DB_PORT|OPSI_API_PORT|OPSI_DEPOT_PORT|OPSI_WEBUI_PORT|PXE_HTTP_PORT|PXE_WEBAPP_PORT|PXE_TFTP_PORT)
+    DB_PORT|REDIS_PORT|OPSI_API_PORT|OPSI_DEPOT_PORT|OPSI_WEBUI_PORT|PXE_HTTP_PORT|PXE_WEBAPP_PORT|PXE_TFTP_PORT)
       if [[ ! "$value" =~ ^[0-9]+$ ]]; then
         warn_invalid_port
         return 1
@@ -555,6 +563,7 @@ ensure_directories() {
     "$DATA_DIR/db"
     "$DATA_DIR/opsi"
     "$DATA_DIR/pxe"
+    "$DATA_DIR/redis"
     "$LOG_DIR"
     "$LOG_DIR/opsi-server"
     "$BACKUP_DIR"


### PR DESCRIPTION
## Summary
- add a Redis service to the docker compose stack and wire the OPSI server to it
- expose Redis configuration defaults via the sample environment file and installer prompts
- document the Redis component in the README and ensure data directories are prepared for it

## Testing
- `bash -n scripts/opsisuit-installer.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c960dd71a48333848bb0b19e4344a1