### PR TITLE
Fix default UID/GID for PXE container

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Konfigurationsdateien überschreiben.
 3. `configs/pxe/pxe.conf` – Beispielkonfiguration für dnsmasq/TFTP.
 4. `configs/agent/client-agent.conf` – Vorgaben für den OPSI-Client-Agenten.
 
+> **Hinweis:** Für den PXE-Container (`netboot.xyz`) muss `SERVICE_UID`/`SERVICE_GID`
+> auf eine reguläre Benutzer-/Gruppen-ID zeigen. Die Standardwerte (`1000`) vermeiden
+> den Fehler `Invalid user name nbxyz` beim Start von `supervisord`. Passen Sie die IDs
+> bei Bedarf an die UID/GID Ihres Docker-Hosts an.
+
 Alle Dateien werden beim ersten Lauf des Installers aus den jeweiligen
 `.example`-Vorlagen kopiert und können anschließend editiert werden.
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -5,8 +5,8 @@ COMPOSE_PROJECT_NAME=opsisuit
 
 # Global service defaults
 TIMEZONE=UTC
-SERVICE_UID=0
-SERVICE_GID=0
+SERVICE_UID=1000
+SERVICE_GID=1000
 
 # Database configuration
 DB_ROOT_PASSWORD=ChangeMeRoot!

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -77,8 +77,8 @@ services:
     container_name: opsisuit-pxe
     restart: unless-stopped
     environment:
-      PUID: ${SERVICE_UID:-0}
-      PGID: ${SERVICE_GID:-0}
+      PUID: ${SERVICE_UID:-1000}
+      PGID: ${SERVICE_GID:-1000}
       TZ: ${TIMEZONE:-UTC}
     ports:
       - "${PXE_TFTP_PORT:-69}:69/udp"

--- a/scripts/opsisuit-installer.sh
+++ b/scripts/opsisuit-installer.sh
@@ -134,8 +134,8 @@ get_env_default() {
     PXE_HTTP_PORT) echo "8080" ;;
     PXE_WEBAPP_PORT) echo "3000" ;;
     PXE_TFTP_PORT) echo "69" ;;
-    SERVICE_UID) echo "0" ;;
-    SERVICE_GID) echo "0" ;;
+    SERVICE_UID) echo "1000" ;;
+    SERVICE_GID) echo "1000" ;;
     TIMEZONE) echo "UTC" ;;
     PXE_IMAGE) echo "netbootxyz/netbootxyz:latest" ;;
     *) echo "" ;;


### PR DESCRIPTION
## Summary
- set the default SERVICE_UID/SERVICE_GID to 1000 so the netboot.xyz container can create its nbxyz user
- document the requirement in the README to avoid the invalid user nbxyz supervisord error
- keep the installer defaults aligned with the Docker Compose and .env example values

## Testing
- ./scripts/opsisuit-installer.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68c962da148083339bfab9a92a8e4935