### PR TITLE
Fix Redis port configuration for opsi server

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -18,6 +18,7 @@ DB_PORT=3306
 # Redis cache
 REDIS_IMAGE=redis:7-alpine
 REDIS_PORT=6379
+REDIS_SERVICE_PORT=6379
 
 # OPSI server configuration
 OPSI_SERVER_IMAGE=uibmz/opsi-server:4.2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,10 +32,12 @@ services:
       - redis-server
       - --appendonly
       - "yes"
+      - --port
+      - "${REDIS_SERVICE_PORT:-6379}"
     volumes:
       - ../data/redis:/data
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_PORT:-6379}:${REDIS_SERVICE_PORT:-6379}"
     networks:
       opsisuit:
         aliases:
@@ -57,7 +59,7 @@ services:
       OPSI_DB_USER: ${DB_USER:-opsi}
       OPSI_DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       OPSI_REDIS_HOST: redis
-      OPSI_REDIS_PORT: ${REDIS_PORT:-6379}
+      OPSI_REDIS_PORT: ${REDIS_SERVICE_PORT:-6379}
       AGENT_SECRET: ${AGENT_SECRET:-ChangeMeAgentSecret!}
       AGENT_POLL_INTERVAL: ${AGENT_POLL_INTERVAL:-3600}
     volumes:

--- a/scripts/opsisuit-installer.sh
+++ b/scripts/opsisuit-installer.sh
@@ -32,6 +32,7 @@ ENV_VARIABLES=(
   DB_PORT
   REDIS_IMAGE
   REDIS_PORT
+  REDIS_SERVICE_PORT
   OPSI_ADMIN_USER
   OPSI_ADMIN_PASSWORD
   OPSI_SERVER_FQDN
@@ -122,6 +123,7 @@ get_env_default() {
     DB_PORT) echo "3306" ;;
     REDIS_IMAGE) echo "redis:7-alpine" ;;
     REDIS_PORT) echo "6379" ;;
+    REDIS_SERVICE_PORT) echo "6379" ;;
     OPSI_ADMIN_USER) echo "opsiadmin" ;;
     OPSI_ADMIN_PASSWORD) echo "" ;;
     OPSI_SERVER_FQDN) echo "opsi.local" ;;
@@ -201,7 +203,8 @@ build_prompt() {
       DB_PASSWORD) label="Passwort für den Datenbankbenutzer" ;;
       DB_PORT) label="Datenbank-Portnummer" ;;
       REDIS_IMAGE) label="Container-Image für Redis" ;;
-      REDIS_PORT) label="Redis-Portnummer" ;;
+      REDIS_PORT) label="Externer Redis-Port (Host)" ;;
+      REDIS_SERVICE_PORT) label="Interner Redis-Port (Container)" ;;
       OPSI_ADMIN_USER) label="OPSI-Administratorbenutzer" ;;
       OPSI_ADMIN_PASSWORD) label="Passwort für den OPSI-Administrator" ;;
       OPSI_SERVER_FQDN) label="FQDN des OPSI-Servers" ;;
@@ -238,7 +241,8 @@ build_prompt() {
       DB_PASSWORD) label="Password for the database user" ;;
       DB_PORT) label="Database port number" ;;
       REDIS_IMAGE) label="Container image for Redis" ;;
-      REDIS_PORT) label="Redis port number" ;;
+      REDIS_PORT) label="Redis host port" ;;
+      REDIS_SERVICE_PORT) label="Redis service port (inside container network)" ;;
       OPSI_ADMIN_USER) label="OPSI administrator user" ;;
       OPSI_ADMIN_PASSWORD) label="Password for the OPSI administrator" ;;
       OPSI_SERVER_FQDN) label="Fully qualified domain name of the OPSI server" ;;
@@ -276,7 +280,7 @@ validate_env_value() {
   local numeric_value=0
 
   case "$var" in
-    DB_PORT|REDIS_PORT|OPSI_API_PORT|OPSI_DEPOT_PORT|OPSI_WEBUI_PORT|PXE_HTTP_PORT|PXE_WEBAPP_PORT|PXE_TFTP_PORT)
+    DB_PORT|REDIS_PORT|REDIS_SERVICE_PORT|OPSI_API_PORT|OPSI_DEPOT_PORT|OPSI_WEBUI_PORT|PXE_HTTP_PORT|PXE_WEBAPP_PORT|PXE_TFTP_PORT)
       if [[ ! "$value" =~ ^[0-9]+$ ]]; then
         warn_invalid_port
         return 1


### PR DESCRIPTION
## Summary
- add a dedicated Redis service port variable and pass it to the opsi server container
- allow overriding host and service Redis ports separately in the installer and sample environment file

## Testing
- ./scripts/opsisuit-installer.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68c96be45e848333b595f824d6bb1aad