### PR TITLE
Lock mission critical ports to defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Konfigurationsdateien überschreiben.
 > den Fehler `Invalid user name nbxyz` beim Start von `supervisord`. Passen Sie die IDs
 > bei Bedarf an die UID/GID Ihres Docker-Hosts an.
 
+> **Mission-Critical Defaults:** Interne Kommunikationsports wie `OPSI_API_PORT`,
+> `OPSI_DEPOT_PORT`, `PXE_TFTP_PORT` und `REDIS_SERVICE_PORT` folgen festen Standards
+> und werden vom Installer nicht mehr abgefragt. Sie werden automatisch mit ihren
+> Default-Werten in `docker/.env` geschrieben, damit zentrale Dienste zuverlässig
+> miteinander kommunizieren. Exponierte HTTP-Ports (z. B. für Web-UIs) bleiben
+> weiterhin konfigurierbar.
+
 Alle Dateien werden beim ersten Lauf des Installers aus den jeweiligen
 `.example`-Vorlagen kopiert und können anschließend editiert werden.
 


### PR DESCRIPTION
## Summary
- define a mission critical variable set in the installer and skip prompting for those entries
- automatically write default values for OPSI API, OPSI depot, PXE TFTP and Redis service ports while flagging them as fixed in the summary
- document the new behaviour in the README so administrators know which ports remain locked to defaults

## Testing
- bash -n scripts/opsisuit-installer.sh

------
https://chatgpt.com/codex/tasks/task_e_68c96df8ad648333bd42bab9f6ff30ee