### PR TITLE
Add Redis healthcheck and conditionally start opsi server

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,11 @@ services:
       - "yes"
       - --port
       - "${REDIS_SERVICE_PORT:-6379}"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - ../data/redis:/data
     ports:
@@ -48,8 +53,10 @@ services:
     container_name: opsisuit-server
     restart: unless-stopped
     depends_on:
-      - db
-      - redis
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_started
     environment:
       OPSI_ADMIN_USER: ${OPSI_ADMIN_USER:-opsiadmin}
       OPSI_ADMIN_PASSWORD: ${OPSI_ADMIN_PASSWORD:?OPSI_ADMIN_PASSWORD is required}


### PR DESCRIPTION
## Summary
- add a healthcheck to the redis service in docker-compose
- require the opsi-server service to wait for the redis health check before starting

## Testing
- docker compose up -d *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c973766bdc83338337f323afa20ad8