### PR TITLE
Fix opsiconfd redis configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ Konfigurationsdateien überschreiben.
 > und werden vom Installer nicht mehr abgefragt. Sie werden automatisch mit ihren
 > Default-Werten in `docker/.env` geschrieben, damit zentrale Dienste zuverlässig
 > miteinander kommunizieren. Exponierte HTTP-Ports (z. B. für Web-UIs) bleiben
-> weiterhin konfigurierbar.
+> weiterhin konfigurierbar. Die Redis-Anbindung des opsiconfd
+> (`OPSICONFD_REDIS_URL`) ist ebenso fest auf
+> `redis://redis:${REDIS_SERVICE_PORT:-6379}/0` gesetzt und wird nicht mehr über
+> `.env` überschrieben.
 
 Alle Dateien werden beim ersten Lauf des Installers aus den jeweiligen
 `.example`-Vorlagen kopiert und können anschließend editiert werden.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,8 +65,7 @@ services:
       OPSI_DB_NAME: ${DB_NAME:-opsi}
       OPSI_DB_USER: ${DB_USER:-opsi}
       OPSI_DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
-      OPSI_REDIS_HOST: redis
-      OPSI_REDIS_PORT: ${REDIS_SERVICE_PORT:-6379}
+      OPSICONFD_REDIS_URL: redis://redis:${REDIS_SERVICE_PORT:-6379}/0
       AGENT_SECRET: ${AGENT_SECRET:-ChangeMeAgentSecret!}
       AGENT_POLL_INTERVAL: ${AGENT_POLL_INTERVAL:-3600}
     volumes:


### PR DESCRIPTION
## Summary
- ensure the opsi-server service pins `OPSICONFD_REDIS_URL` to the internal Redis instance
- document that the redis URL is treated as mission-critical and drop the `.env` override example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c978248c9c8333ab66ea00f260e25f