### PR TITLE
Ensure opsi server uses FQDN hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Konfigurationsdateien überschreiben.
 > `redis://redis:${REDIS_SERVICE_PORT:-6379}/0` gesetzt und wird nicht mehr über
 > `.env` überschrieben.
 
+> **FQDN erforderlich:** Der OPSI-Server-Container übernimmt den in `.env`
+> definierten `OPSI_SERVER_FQDN` direkt als Hostnamen. Verwenden Sie deshalb immer
+> einen vollqualifizierten Domainnamen (z. B. `opsi.example.local`). Andernfalls
+> verweigert `opsiconfd` den Start mit `ValueError: Bad fqdn`.
+
 Alle Dateien werden beim ersten Lauf des Installers aus den jeweiligen
 `.example`-Vorlagen kopiert und können anschließend editiert werden.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,6 +51,7 @@ services:
   opsi-server:
     image: ${OPSI_SERVER_IMAGE:-uibmz/opsi-server:4.2}
     container_name: opsisuit-server
+    hostname: ${OPSI_SERVER_FQDN:-opsi.local}
     restart: unless-stopped
     depends_on:
       redis:

--- a/scripts/opsisuit-installer.sh
+++ b/scripts/opsisuit-installer.sh
@@ -208,6 +208,14 @@ warn_invalid_integer() {
   fi
 }
 
+warn_invalid_fqdn() {
+  if language_is_de; then
+    log_warn "Bitte einen vollqualifizierten Domainnamen angeben (z. B. opsi.example.local)."
+  else
+    log_warn "Please provide a fully qualified domain name (e.g. opsi.example.local)."
+  fi
+}
+
 build_prompt() {
   local var="$1"
   local default_value="$2"
@@ -312,6 +320,12 @@ validate_env_value() {
     SERVICE_UID|SERVICE_GID|AGENT_POLL_INTERVAL)
       if [[ ! "$value" =~ ^[0-9]+$ ]]; then
         warn_invalid_integer
+        return 1
+      fi
+      ;;
+    OPSI_SERVER_FQDN)
+      if [[ ! "$value" =~ ^[A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?(\.[A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?)+$ ]]; then
+        warn_invalid_fqdn
         return 1
       fi
       ;;


### PR DESCRIPTION
## Summary
- set the opsi-server container hostname to the configured FQDN so opsiconfd gets a valid host name
- add installer validation and docs explaining that OPSI_SERVER_FQDN must be a fully qualified domain name

## Testing
- bash -n scripts/opsisuit-installer.sh

------
https://chatgpt.com/codex/tasks/task_e_68c98805e858833381794178f430697f