### PR TITLE
Fix opsiconfd startup by aligning backend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ vereinfachen soll.
 | Service       | Beschreibung                                                                 |
 |---------------|------------------------------------------------------------------------------|
 | `db`          | MariaDB 10.11 als zentrales Backend für OPSI.                                |
-| `redis`       | Redis 7 als In-Memory-Cache und Message-Broker für den OPSI-Server.          |
+| `redis`       | Redis Stack (inkl. RedisTimeSeries) als Cache und Metrik-Backend für OPSI.    |
 | `opsi-server` | OPSI-Server inklusive Config-API und Depot. Greift auf DB und Konfigurationen zu. |
 | `pxe`         | netboot.xyz TFTP/HTTP-Service mit Webinterface (Standard: `netbootxyz/netbootxyz`). |
 
@@ -111,6 +111,11 @@ Konfigurationsdateien überschreiben.
 > (`OPSICONFD_REDIS_URL`) ist ebenso fest auf
 > `redis://redis:${REDIS_SERVICE_PORT:-6379}/0` gesetzt und wird nicht mehr über
 > `.env` überschrieben.
+>
+> **Backend-URL Handling:** Die Angaben unter `DB_*` werden zusätzlich als `MYSQL_*`
+> in den OPSI-Server-Container durchgereicht. Dadurch nutzt der offizielle
+> `uibmz/opsi-server`-Entrypoint zuverlässig den MariaDB-Dienst `db` statt auf
+> `127.0.0.1` zurückzufallen.
 
 > **FQDN erforderlich:** Der OPSI-Server-Container übernimmt den in `.env`
 > definierten `OPSI_SERVER_FQDN` direkt als Hostnamen. Verwenden Sie deshalb immer

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -16,7 +16,7 @@ DB_PASSWORD=ChangeMeDb!
 DB_PORT=3306
 
 # Redis cache
-REDIS_IMAGE=redis:7-alpine
+REDIS_IMAGE=redis/redis-stack-server:latest
 REDIS_PORT=6379
 REDIS_SERVICE_PORT=6379
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,11 +25,11 @@ services:
           - db
 
   redis:
-    image: ${REDIS_IMAGE:-redis:7-alpine}
+    image: ${REDIS_IMAGE:-redis/redis-stack-server:latest}
     container_name: opsisuit-redis
     restart: unless-stopped
     command:
-      - redis-server
+      - redis-stack-server
       - --appendonly
       - "yes"
       - --port
@@ -66,6 +66,12 @@ services:
       OPSI_DB_NAME: ${DB_NAME:-opsi}
       OPSI_DB_USER: ${DB_USER:-opsi}
       OPSI_DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      MYSQL_HOST: db
+      MYSQL_PORT: ${DB_PORT:-3306}
+      MYSQL_DATABASE: ${DB_NAME:-opsi}
+      MYSQL_USER: ${DB_USER:-opsi}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      REDIS_HOST: redis
       OPSICONFD_REDIS_URL: redis://redis:${REDIS_SERVICE_PORT:-6379}/0
       AGENT_SECRET: ${AGENT_SECRET:-ChangeMeAgentSecret!}
       AGENT_POLL_INTERVAL: ${AGENT_POLL_INTERVAL:-3600}

--- a/scripts/opsisuit-installer.sh
+++ b/scripts/opsisuit-installer.sh
@@ -128,7 +128,7 @@ get_env_default() {
     DB_USER) echo "opsi" ;;
     DB_PASSWORD) echo "" ;;
     DB_PORT) echo "3306" ;;
-    REDIS_IMAGE) echo "redis:7-alpine" ;;
+    REDIS_IMAGE) echo "redis/redis-stack-server:latest" ;;
     REDIS_PORT) echo "6379" ;;
     REDIS_SERVICE_PORT) echo "6379" ;;
     OPSI_ADMIN_USER) echo "opsiadmin" ;;


### PR DESCRIPTION
## Summary
- switch the Redis container to redis-stack so RedisTimeSeries commands required by opsiconfd are available
- pass the MariaDB credentials as MYSQL_* variables to the opsi-server container to avoid 127.0.0.1 fallbacks
- update defaults, documentation and installer template to reflect the new Redis image and backend wiring

## Testing
- ./scripts/opsisuit-installer.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68c98b3bdf708333a2ae6d96cea0ba32