### PR TITLE
Translate documentation to English

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -1,116 +1,115 @@
 # Agent: OpsiSuit
 
-## Überblick
+## Overview
 
-**Name:** OpsiSuit  
-**Zweck:** Automatisierte Einrichtung und Verwaltung einer vollständigen OPSI‑Infrastructure (OS‑Deployment, Applikationsdeployment, Inventarisierung).  
-**Zielplattform:** Linux‑Server (am besten Debian / Ubuntu / CentOS / RHEL etc.), möglichst unter Docker oder mittels Containerisierung.  
+**Name:** OpsiSuit
+**Purpose:** Automated setup and management of a complete OPSI infrastructure (OS deployment, application deployment, inventory).
+**Target platform:** Linux servers (preferably Debian / Ubuntu / CentOS / RHEL etc.), ideally under Docker or using containerization.
 
-OpsiSuit übernimmt:
+OpsiSuit handles:
 
-- Installation und Konfiguration des Opsi‑Servers und aller zugehörigen Komponenten  
-- Einrichtung von Opsi‑Clients / Agenten auf Zielrechnern  
-- Verwaltung von App‑Deployments  
-- OS‑Deployment (Installation, Imaging, Partitionierung etc.)  
-- Inventarisierung: Hardware, Software, Konfiguration  
-
----
-
-## Komponenten & Architektur
-
-| Komponente | Beschreibung |
-|------------|--------------|
-| **Opsi Server** | Zentrale Komponente, steuert Deployment, Inventarisierung, Clients. |
-| **Database** | z. B. MariaDB / MySQL / PostgreSQL zur Speicherung von Opsi‑Daten. |
-| **Web Frontend / Management UI** | Weboberfläche zur Verwaltung von Images, Paketen, Clients etc. |
-| **Tftp / PXE + Netboot Komponenten** | Für OS‑Deployment über Netzwerk, Boot images etc. |
-| **Package Repo / Paketmanagement** | Stores für Softwarepakete, Updates etc. |
-| **Client‑Agent** | Wird auf Zielmaschinen installiert, führt Deployment, Inventarisierung etc. aus. |
-| **Inventarisierung Modul** | Script / Agent, der Hardware‑ & Softwaredaten sammelt und zurückmeldet. |
-
-Wenn möglich, alles in Containern betrieben, mit klarer Trennung z. B. Datenbank, Webfrontend, PXE/TFTP, Agent etc.  
+- Installation and configuration of the OPSI server and all related components
+- Provisioning of OPSI clients / agents on target machines
+- Management of application deployments
+- OS deployment (installation, imaging, partitioning, etc.)
+- Inventory: hardware, software, configuration
 
 ---
 
-## Installations‑ und Setupablauf
+## Components & Architecture
 
-1. **Servervorbereitung**  
-   - Linux‑Server mit minimaler Installation  
-   - Basis‑Pakete: Docker / Docker‑Compose (oder Podman), Git, Curl, ggf. Firewall / Netzkonfiguration  
-   - Netzwerk vorbereiten (z. B. DHCP + PXE, statische IP etc.), DNS falls benötigt  
+| Component | Description |
+|-----------|-------------|
+| **OPSI Server** | Central component that controls deployment, inventory, and clients. |
+| **Database** | e.g., MariaDB / MySQL / PostgreSQL for storing OPSI data. |
+| **Web Frontend / Management UI** | Web interface for managing images, packages, clients, etc. |
+| **Tftp / PXE + Netboot Components** | For OS deployment over the network, boot images, etc. |
+| **Package Repository / Package Management** | Stores for software packages, updates, etc. |
+| **Client Agent** | Installed on target machines to execute deployment, inventory, etc. |
+| **Inventory Module** | Script / agent that collects hardware and software data and reports back. |
 
-2. **Containerisierte Komponenten (falls Docker verwendet wird)**  
-   - Definieren von Docker‑Compose / Stack: Services für Opsi Backend, Datenbank, Web Frontend, PXE/TFTP, ggf. Proxy/Load Balancer  
-   - Persistente Volumes konfigurieren (z. B. DB Daten, Logs, Images)  
-   - Netzwerke und Ports (z. B. HTTP/HTTPS, TFTP, DHCP etc.)  
-
-3. **OPSI Server Installation & Konfiguration**  
-   - OPSI Paketquelle hinzufügen  
-   - Installation der OPSI Server Komponenten  
-   - Einrichtung Datenbank (Schema, Nutzer, Berechtigungen)  
-   - Web UI konfigurieren, SSL (z. B. mittels Let’s Encrypt)  
-
-4. **PXE / Netboot Setup**  
-   - TFTP / DHCP-Konfiguration (sofern nicht bereits vorhanden)  
-   - Netboot‑Images vorbereiten  
-   - Boot‑Konfiguration (z. B. Linux Kernel + Initrd)  
-
-5. **Client Agent Setup**  
-   - Automatisches Ausrollen des Agenten auf Zielrechner (z. B. via SSH, via OPSI selbst)  
-   - Sicherstellung, dass Inventarisierungs‑Modul läuft und regelmäßig Daten an Server sendet  
-
-6. **App‑ und OS Deployment Setup**  
-   - Definition von OS Images (Konfiguration, Partitionierung, Treiber etc.)  
-   - App Paket‑Repos (Windows / Linux Applikationen)  
-   - Deployment Scripts / Tasks definieren  
-   - Rollout / Update Management  
-
-7. **Inventarisierung**  
-   - Erfassen von Hardwaredaten (CPU, RAM, Festplatten, Netzwerkkarten etc.)  
-   - Erfassen von installierter Software & Versionen  
-   - Logik zur Erkennung von Abweichungen / fehlenden Updates  
-
-8. **Monitoring & Backup**  
-   - Logsammlung, Monitoring der Dienste (z. B. via Prometheus, Grafana oder simpler Überwachung)  
-   - Backup der Datenbank, der Konfiguration, der Images  
+If possible, run everything in containers with a clear separation, e.g., database, web frontend, PXE/TFTP, agent, etc.
 
 ---
 
-## Stilrichtlinien & Best Practices für den Agenten
+## Installation and Setup Flow
 
-- **Idempotenz:** Aktionen mehrfach ausgeführt erzeugen keinen Fehlerzustand.  
-- **Konfigurierbarkeit:** Möglichst viele Parameter extern (z. .ENV, YAML, etc.) einstellbar: Ports, Pfade, Datenbank‑Credentials, Netzwerk etc.  
-- **Modularität:** Jeder Teil (DB, Web UI, PXE, Agent, Inventarisierung) möglichst isoliert, austauschbar.  
-- **Sicherheit:**  
-  - SSL/TLS für Webinterfaces  
-  - sichere Credentials, ggf. Secrets Management  
-  - eingeschränkter Zugang zu PXE/TFTP etc.  
-- **Logging & Fehlerbehandlung:** Klare Logs, verständliche Fehlermeldungen, Recovery‑Pfade.  
-- **Dokumentation & Testing:** Jede Komponente sollte dokumentiert sein (Setup, Nutzung), automatische Tests / Validierungen sofern möglich.  
+1. **Server preparation**
+   - Linux server with a minimal installation
+   - Base packages: Docker / Docker Compose (or Podman), Git, Curl, possibly firewall / network configuration
+   - Prepare the network (e.g., DHCP + PXE, static IP, DNS if required)
+
+2. **Containerized components (if Docker is used)**
+   - Define Docker Compose / stack: services for OPSI backend, database, web frontend, PXE/TFTP, optionally proxy/load balancer
+   - Configure persistent volumes (e.g., database data, logs, images)
+   - Networks and ports (e.g., HTTP/HTTPS, TFTP, DHCP, etc.)
+
+3. **OPSI server installation & configuration**
+   - Add OPSI package source
+   - Install the OPSI server components
+   - Set up the database (schema, user, permissions)
+   - Configure the web UI, SSL (e.g., using Let's Encrypt)
+
+4. **PXE / Netboot setup**
+   - Configure TFTP / DHCP (if not already available)
+   - Prepare netboot images
+   - Boot configuration (e.g., Linux kernel + initrd)
+
+5. **Client agent setup**
+   - Automatically roll out the agent to target machines (e.g., via SSH, via OPSI itself)
+   - Ensure that the inventory module runs and regularly sends data back to the server
+
+6. **App and OS deployment setup**
+   - Define OS images (configuration, partitioning, drivers, etc.)
+   - Application package repositories (Windows / Linux applications)
+   - Define deployment scripts / tasks
+   - Rollout / update management
+
+7. **Inventory**
+   - Collect hardware data (CPU, RAM, disks, network cards, etc.)
+   - Collect installed software and versions
+   - Logic to detect deviations / missing updates
+
+8. **Monitoring & Backup**
+   - Collect logs, monitor services (e.g., via Prometheus, Grafana or simple monitoring)
+   - Back up the database, configuration, and images
 
 ---
 
-## Technische Hinweise & Defaults
+## Style Guidelines & Best Practices for the Agent
 
-- **Betriebssysteme (Server):** Debian 12 / Ubuntu LTS / CentOS / RockyLinux  
-- **Datenbank:** MariaDB oder PostgreSQL, Standby oder Replikation optional  
-- **Container Orchestrierung:** Docker + Docker‑Compose, optional Kubernetes in großen Setups  
-- **Web UI:** Vorzugsweise der standardmäßige Opsi Webinstaller / Opsi ConfigAPI, ggf. eigenes Dashboard  
-- **Netzwerkdienste:**  
-  - DHCP Server oder Interaktion mit existierendem DHCP  
-  - PXE/TFTP über UDP Port 69 + entsprechende Ports  
-  - HTTP/HTTPS für Datei‑ und Paketbereitstellung  
-- **Agenten:** Unterstützt Windows und Linux Clients  
-- **Inventarisierungstakt:** z. B. tägliches Inventar, bei großen Umgebungen ggf. stündlich oder nach Bedarf  
+- **Idempotence:** Running actions multiple times must not create an error state.
+- **Configurability:** As many parameters as possible should be configurable externally (e.g., .ENV, YAML, etc.): ports, paths, database credentials, network, etc.
+- **Modularity:** Each part (database, web UI, PXE, agent, inventory) should be as isolated and interchangeable as possible.
+- **Security:**
+  - SSL/TLS for web interfaces
+  - Secure credentials, ideally secrets management
+  - Restricted access to PXE/TFTP, etc.
+- **Logging & error handling:** Clear logs, understandable error messages, recovery paths.
+- **Documentation & testing:** Each component should be documented (setup, usage) with automated tests / validations where possible.
 
 ---
 
-## Vorschlag für Ordnerstruktur / Repository
+## Technical Notes & Defaults
 
-Eine mögliche Struktur in einem Git‑Repository:
+- **Operating systems (server):** Debian 12 / Ubuntu LTS / CentOS / Rocky Linux
+- **Database:** MariaDB or PostgreSQL, standby or replication optional
+- **Container orchestration:** Docker + Docker Compose, optionally Kubernetes for large setups
+- **Web UI:** Preferably the standard OPSI web installer / OPSI ConfigAPI, optionally a custom dashboard
+- **Network services:**
+  - DHCP server or integration with an existing DHCP service
+  - PXE/TFTP over UDP port 69 + corresponding ports
+  - HTTP/HTTPS for file and package delivery
+- **Agents:** Support Windows and Linux clients
+- **Inventory interval:** e.g., daily inventory; for large environments possibly hourly or as required
+
+---
+
+## Suggested Folder Structure / Repository Layout
+
+A possible structure for a Git repository:
 
 ```
-
 opsisuit/
 ├── docker/
 │   ├── docker-compose.yml
@@ -124,34 +123,34 @@ opsisuit/
 ├── configs/
 │   ├── opsi.conf
 │   ├── pxe/
-│   └── client\_agent.conf
+│   └── client_agent.conf
 ├── scripts/
-│   ├── setup\_server.sh
-│   ├── setup\_agent.sh
-│   └── inventory\_collector.sh
+│   ├── setup_server.sh
+│   ├── setup_agent.sh
+│   └── inventory_collector.sh
 ├── images/
-│   └── os\_templates/
+│   └── os_templates/
 ├── docs/
 │   ├── installation.md
 │   ├── usage.md
 │   └── troubleshooting.md
 └── tests/
-├── ci\_tests/
-└── integration\_tests/
+├── ci_tests/
+└── integration_tests/
 
 ````
 
 ---
 
-## Schnittstellen & API
+## Interfaces & API
 
-- **ConfigAPI** von Opsi nutzen für automatisierte Steuerung (Pakete, Clients, Aufgaben).  
-- REST‑API endpoint im Agenten, um Inventarisierungsdaten zu liefern.  
-- Falls nötig Webhooks oder Events für Statusänderungen oder Fehler.  
+- Use the OPSI ConfigAPI for automated control (packages, clients, tasks).
+- REST API endpoint in the agent to submit inventory data.
+- Webhooks or events for status changes or errors if required.
 
 ---
 
-## Beispiel Konfigurationsvariablen (ENV / YAML)
+## Example Configuration Variables (ENV / YAML)
 
 ```yaml
 server:
@@ -183,20 +182,19 @@ webui:
 
 ---
 
-## Aufgaben / User Stories
+## Tasks / User Stories
 
-Damit der Agent aussagekräftig entwickelt werden kann, ein paar User Stories:
+To guide the development of the agent, a few user stories:
 
-* Als Administrator möchte ich mit einem einzigen Kommando den kompletten OPSI‑Server im Docker‑Setup aufsetzen.
-* Als Administrator will ich neue Clients automatisch inventarisieren können, sobald sie im Netzwerk sind.
-* Als Administrator möchte ich OS Images definieren und auf neue Maschinen deployen können.
-* Als Administrator will ich Applikationen auf Clients ausrollen und Updates steuern können.
-* Als Administrator möchte ich Zugriff auf Logs / Status‑Views über eine Web UI haben.
+* As an administrator I want to set up the entire OPSI server in a Docker setup with a single command.
+* As an administrator I want new clients to be inventoried automatically as soon as they appear on the network.
+* As an administrator I want to define OS images and deploy them to new machines.
+* As an administrator I want to roll out applications to clients and control updates.
+* As an administrator I want access to logs / status views through a web UI.
 
 ---
 
-## Zusammenfassung
+## Summary
 
-OpsiSuit soll eine **vollständige, modulare, automatisierte Lösung** sein, mit der man schnell eine OPSI‑Infrastruktur auf Linux (ideal Docker) aufsetzen kann, OS & App Deployment steuern sowie Inventarisierung betreiben. Sicherheit, Konfigurierbarkeit und Wartbarkeit sind Kernelemente.
-
+OpsiSuit aims to be a **complete, modular, automated solution** that allows you to quickly set up an OPSI infrastructure on Linux (ideally Docker), manage OS & app deployments, and handle inventory. Security, configurability, and maintainability are core elements.
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,52 @@
 # OpsiSuit
 
-OpsiSuit soll eine automatisierte, containerisierte OPSI-Infrastruktur aufbauen. Das
-Projekt bündelt die notwendigen Komponenten (OPSI-Server, Datenbank, PXE/TFTP und
-Agenten-Konfiguration) und liefert ein Installationsskript, das den ersten Aufbau
-vereinfachen soll.
+OpsiSuit is intended to build an automated, containerized OPSI infrastructure. The
+project bundles the required components (OPSI server, database, PXE/TFTP, and
+agent configuration) and provides an installation script to simplify the initial
+setup.
 
-## Aktueller Stand
+## Current Status
 
-- Initiale Repository-Struktur mit Docker Compose Stack.
-- Beispielkonfigurationen für OPSI-Server, PXE/TFTP und Client-Agent.
-- Installer-Skript (`scripts/opsisuit-installer.sh`), das Abhängigkeiten prüft,
-  Konfigurationsdateien bereitstellt und den Compose-Stack starten kann.
+- Initial repository structure with Docker Compose stack.
+- Sample configurations for OPSI server, PXE/TFTP, and client agent.
+- Installer script (`scripts/opsisuit-installer.sh`) that checks dependencies,
+  provides configuration files, and can start the compose stack.
 
-## Komponenten im Compose-Stack
+## Components in the Compose Stack
 
-| Service       | Beschreibung                                                                 |
+| Service       | Description                                                                 |
 |---------------|------------------------------------------------------------------------------|
-| `db`          | MariaDB 10.11 als zentrales Backend für OPSI.                                |
-| `redis`       | Redis Stack (inkl. RedisTimeSeries) als Cache und Metrik-Backend für OPSI.    |
-| `opsi-server` | OPSI-Server inklusive Config-API und Depot. Greift auf DB und Konfigurationen zu. |
-| `pxe`         | netboot.xyz TFTP/HTTP-Service mit Webinterface (Standard: `netbootxyz/netbootxyz`). |
+| `db`          | MariaDB 10.11 as the central backend for OPSI.                              |
+| `redis`       | Redis Stack (including RedisTimeSeries) as cache and metrics backend for OPSI. |
+| `opsi-server` | OPSI server including Config API and depot. Accesses the database and configurations. |
+| `pxe`         | netboot.xyz TFTP/HTTP service with web interface (default: `netbootxyz/netbootxyz`). |
 
-## Repository-Struktur
+## Repository Structure
 
 ```
 .
-├── configs/                # Beispiel- und Zielkonfigurationen
+├── configs/                # Sample and target configurations
 │   ├── agent/
 │   ├── opsi/
 │   └── pxe/
 ├── docker/
-│   ├── .env.example        # Beispielwerte für den Compose-Stack
+│   ├── .env.example        # Example values for the compose stack
 │   └── docker-compose.yml
 ├── scripts/
 │   └── opsisuit-installer.sh
 └── README.md
 ```
 
-Die tatsächlichen Konfigurationsdateien ohne `.example` werden vom Installer
-gelegt und sind per `.gitignore` vom Repository ausgeschlossen.
+The actual configuration files without `.example` are created by the installer
+and are excluded from the repository via `.gitignore`.
 
-## Voraussetzungen
+## Prerequisites
 
-- Linux-Host (Debian/Ubuntu, RHEL/CentOS/Rocky, openSUSE oder Arch/Manjaro).
-- Docker und Docker Compose (Plugin oder `docker-compose`).
-- `curl` und `git`.
+- Linux host (Debian/Ubuntu, RHEL/CentOS/Rocky, openSUSE, or Arch/Manjaro).
+- Docker and Docker Compose (plugin or `docker-compose`).
+- `curl` and `git`.
 
-**Kurzinstallation (Debian/Ubuntu):**
+**Quick installation (Debian/Ubuntu):**
 
 ```bash
 sudo apt update
@@ -55,89 +55,81 @@ sudo systemctl enable --now docker
 sudo usermod -aG docker "$USER"
 ```
 
-> Nach dem Hinzufügen zur `docker`-Gruppe ist eine neue Terminal-Sitzung nötig,
-> damit die Berechtigungen greifen.
+> After adding yourself to the `docker` group you need a new terminal session so that the permissions take effect.
 
-Installationshinweise für weitere Distributionen stehen in
+Installation notes for additional distributions can be found in
 [docs/requirements-installation.md](docs/requirements-installation.md).
 
-Das Installer-Skript kann fehlende Pakete optional automatisch nachinstallieren.
+The installer script can optionally install missing packages automatically.
 
-## Installer verwenden
+## Using the Installer
 
 ```bash
-# Übersicht anzeigen
+# Show overview
 ./scripts/opsisuit-installer.sh --help
 
-# Vollständige Installation inkl. Start des Stacks
+# Full installation including starting the stack
 sudo ./scripts/opsisuit-installer.sh --auto-install-deps
 
-# Nur Dateien vorbereiten, ohne Container zu starten
+# Only prepare files without starting containers
 ./scripts/opsisuit-installer.sh --skip-start
 
-# Testlauf ohne Änderungen
+# Dry run without changes
 ./scripts/opsisuit-installer.sh --dry-run
 ```
 
-Das Skript führt folgende Schritte aus:
+The script performs the following steps:
 
-1. Anlegen benötigter Verzeichnisse (`data/`, `logs/`, `backups/`, `configs/`).
-2. Kopieren der `.example`-Konfigurationsdateien zu editierbaren Vorlagen.
-3. Prüfen bzw. (optional) Installieren der Abhängigkeiten.
-4. Start des Docker-Compose-Stacks (`docker compose up -d`).
+1. Create required directories (`data/`, `logs/`, `backups/`, `configs/`).
+2. Copy `.example` configuration files to editable templates.
+3. Check and optionally install dependencies.
+4. Start the Docker Compose stack (`docker compose up -d`).
 
-Mit `--force-env` bzw. `--force-config` lassen sich vorhandene `.env`- bzw.
-Konfigurationsdateien überschreiben.
+Use `--force-env` or `--force-config` to overwrite existing `.env` or
+configuration files.
 
-## Konfiguration anpassen
+## Adjusting the Configuration
 
-1. `docker/.env` – zentrale Variablen für den Compose-Stack
-   (Ports, Passwörter, Image-Tags, Secrets).
-2. `configs/opsi/opsi.conf` – Beispiel-Fragment für globale OPSI-Einstellungen
-   (bei Bedarf nach `data/opsi/etc/conf.d/` kopieren).
-3. `configs/pxe/pxe.conf` – Beispielkonfiguration für dnsmasq/TFTP.
-4. `configs/agent/client-agent.conf` – Vorlage für den OPSI-Client-Agenten
-   (nach `data/opsi/etc/agent.d/` kopieren).
+1. `docker/.env` – central variables for the compose stack
+   (ports, passwords, image tags, secrets).
+2. `configs/opsi/opsi.conf` – sample snippet for global OPSI settings
+   (copy to `data/opsi/etc/conf.d/` if needed).
+3. `configs/pxe/pxe.conf` – sample configuration for dnsmasq/TFTP.
+4. `configs/agent/client-agent.conf` – template for the OPSI client agent
+   (copy to `data/opsi/etc/agent.d/` as required).
 
-> **Persistente Datenablage:** Der OPSI-Server verschiebt beim Start seine
-> Verzeichnisse `/etc/opsi`, `/var/lib/opsi`, `/var/log/opsi` sowie
-> `/var/lib/opsiconfd` nach `/data` im Container. Dieses komplette Datenverzeichnis
-> ist auf dem Host unter `data/opsi/` zu finden. Logs liegen somit unter
-> `data/opsi/log/`. Die Ordner `configs/opsi/` und `configs/agent/` enthalten
-> weiterhin Beispiel-Fragmente, die bei Bedarf nach `data/opsi/etc/conf.d/` bzw.
-> `data/opsi/etc/agent.d/` kopiert werden können, um eigene Einstellungen
-> einzuspielen.
+> **Persistent data storage:** When it starts, the OPSI server moves its
+> directories `/etc/opsi`, `/var/lib/opsi`, `/var/log/opsi`, and
+> `/var/lib/opsiconfd` into `/data` inside the container. The entire data
+> directory is available on the host under `data/opsi/`. Logs are therefore
+> located under `data/opsi/log/`. The folders `configs/opsi/` and
+> `configs/agent/` continue to hold sample snippets that can be copied to
+> `data/opsi/etc/conf.d/` or `data/opsi/etc/agent.d/` to inject custom
+> settings.
 
-> **Hinweis:** Für den PXE-Container (`netboot.xyz`) muss `SERVICE_UID`/`SERVICE_GID`
-> auf eine reguläre Benutzer-/Gruppen-ID zeigen. Die Standardwerte (`1000`) vermeiden
-> den Fehler `Invalid user name nbxyz` beim Start von `supervisord`. Passen Sie die IDs
-> bei Bedarf an die UID/GID Ihres Docker-Hosts an.
+> **Note:** For the PXE container (`netboot.xyz`), `SERVICE_UID`/`SERVICE_GID`
+> must refer to a regular user/group ID. The default values (`1000`) prevent
+> the error `Invalid user name nbxyz` when `supervisord` starts. Adjust the IDs
+> to match the UID/GID of your Docker host if necessary.
 
-> **Mission-Critical Defaults:** Interne Kommunikationsports wie `OPSI_API_PORT`,
-> `OPSI_DEPOT_PORT`, `PXE_TFTP_PORT` und `REDIS_SERVICE_PORT` folgen festen Standards
-> und werden vom Installer nicht mehr abgefragt. Sie werden automatisch mit ihren
-> Default-Werten in `docker/.env` geschrieben, damit zentrale Dienste zuverlässig
-> miteinander kommunizieren. Exponierte HTTP-Ports (z. B. für Web-UIs) bleiben
-> weiterhin konfigurierbar. Die Redis-Anbindung des opsiconfd
-> (`OPSICONFD_REDIS_URL`) ist ebenso fest auf
-> `redis://redis:${REDIS_SERVICE_PORT:-6379}/0` gesetzt und wird nicht mehr über
-> `.env` überschrieben.
->
-> **Backend-URL Handling:** Die Angaben unter `DB_*` werden zusätzlich als `MYSQL_*`
-> in den OPSI-Server-Container durchgereicht. Dadurch nutzt der offizielle
-> `uibmz/opsi-server`-Entrypoint zuverlässig den MariaDB-Dienst `db` statt auf
-> `127.0.0.1` zurückzufallen.
+> **Mission-critical defaults:** Internal communication ports such as `OPSI_API_PORT`,
+> `OPSI_DEPOT_PORT`, `PXE_TFTP_PORT`, and `REDIS_SERVICE_PORT` follow fixed
+> standards and are no longer queried by the installer. They are written with
+> their default values into `docker/.env` so that the core services can communicate
+> reliably. Exposed HTTP ports (e.g., for web UIs) remain configurable. The Redis
+> connection for opsiconfd (`OPSICONFD_REDIS_URL`) is also fixed to
+> `redis://redis:${REDIS_SERVICE_PORT:-6379}/0` and is no longer overwritten via `.env`.
 
-> **FQDN erforderlich:** Der OPSI-Server-Container übernimmt den in `.env`
-> definierten `OPSI_SERVER_FQDN` direkt als Hostnamen. Verwenden Sie deshalb immer
-> einen vollqualifizierten Domainnamen (z. B. `opsi.example.local`). Andernfalls
-> verweigert `opsiconfd` den Start mit `ValueError: Bad fqdn`.
+> **FQDN required:** The OPSI server container adopts the `OPSI_SERVER_FQDN`
+> defined in `.env` directly as its hostname. Always use a fully qualified domain
+> name (e.g., `opsi.example.local`). Otherwise `opsiconfd` refuses to start with
+> `ValueError: Bad fqdn`.
 
-Alle Dateien werden beim ersten Lauf des Installers aus den jeweiligen
-`.example`-Vorlagen kopiert und können anschließend editiert werden.
+All files are copied from their respective `.example` templates during the
+installer's first run and can then be edited.
 
-## Nächste Schritte
+## Next Steps
 
-- Ausarbeitung der OPSI-spezifischen Konfigurationswerte und Secrets.
-- Ergänzung weiterer Services (z. B. Webfrontend, Monitoring, Inventarisierung).
-- Automatisierte Tests und Validierung der Deployment-Schritte.
+- Work out the OPSI-specific configuration values and secrets.
+- Add additional services (e.g., web frontend, monitoring, inventory).
+- Automated tests and validation of deployment steps.

--- a/docs/requirements-installation.md
+++ b/docs/requirements-installation.md
@@ -1,14 +1,13 @@
-# Schnellinstallation der Voraussetzungen
+# Quick Installation of Prerequisites
 
-Die folgenden Kurz-Anleitungen zeigen, wie sich die in der README genannten
-Pakete (`docker`, `docker compose`, `curl`, `git`) auf gängigen Distributionen
-installieren lassen. Alle Beispiele setzen `sudo`-Rechte voraus.
+The following quick guides show how to install the packages listed in the README
+(`docker`, `docker compose`, `curl`, `git`) on common distributions. All examples
+assume `sudo` privileges.
 
-> **Hinweis:** Nach dem Hinzufügen zur `docker`-Gruppe ist eine neue
-> Terminal-Sitzung (oder Ab- und Anmeldung) erforderlich, damit die
-> Berechtigungen greifen.
+> **Note:** After adding yourself to the `docker` group you need a new terminal
+> session (or log out and back in) so that the permissions take effect.
 
-## Debian / Ubuntu / Derivate
+## Debian / Ubuntu / Derivatives
 
 ```bash
 sudo apt update
@@ -44,7 +43,7 @@ sudo systemctl enable --now docker
 sudo usermod -aG docker "$USER"
 ```
 
-## Installation prüfen
+## Verify the Installation
 
 ```bash
 docker --version
@@ -53,4 +52,4 @@ curl --version
 git --version
 ```
 
-Wenn alle Befehle eine Versionsnummer ausgeben, sind die Voraussetzungen erfüllt.
+If all commands print a version number, the prerequisites are satisfied.


### PR DESCRIPTION
## Summary
- translate Agents.md into English to describe the OpsiSuit agent architecture and guidelines
- update README.md with an English overview, usage instructions, and configuration notes
- convert docs/requirements-installation.md into English quick-start instructions for dependencies

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9acfba77883339803521cb8aba135